### PR TITLE
Typo in out-of-range check.

### DIFF
--- a/src/core/[INT] quad.yolol
+++ b/src/core/[INT] quad.yolol
@@ -7,7 +7,7 @@ j=-140483.070 k=  103669.797 l=799664.698 m=-264673.522 n= -4718.935        //No
 o=-230400.908 p=  345153.593 q= 41051.448 r= -43636.344 s= -1606.533        //Not final values
 a+=y b+=y c+=y d+=y a=(t-:A)^2 b=(t-:B)^2 c=(t-:C)^2 d=(t-:D)^2         
 :X=a/e+b/f+c/g+d/h-i :Y=a/j+b/k+c/l+d/m-n :Z=a/o+b/p+c/q+d/r-s :I++
-:ISAN=u+:X+v+:Y+w+:Z goto 8+3*(a>x+b>x+c>x>d>x)>0
+:ISAN=u+:X+v+:Y+w+:Z goto 8+3*(a>x+b>x+c>x+d>x)>0
 :ISAN="\nYou've left ISAN range!"
 :X=0 :Y=0 :Z=0 :I=-1 goto 11+7*(:A*:B*:C*:D)>0
 is="\nISAN cannot reach your ABCD receiver(s)" :A=0 is-="A"


### PR DESCRIPTION
Typo in goto math would cause it to fail to detect out-of-range events.

@Collective-SB/isan-dev-team