### PR TITLE
Fix for Speed Display Bug

### DIFF
--- a/bundles/basic/ISAN-basic_bundle.yasm
+++ b/bundles/basic/ISAN-basic_bundle.yasm
@@ -143,7 +143,7 @@
     los_msg="\nsignal lost";
     x/=so;
     sm=empty_string;
-    s=empty_string;
+    ss=empty_string;
 
 @_consts_c:
     rr="ISAN2 :_\n     ";

--- a/bundles/basic/ISAN-basic_bundle.yolol
+++ b/bundles/basic/ISAN-basic_bundle.yolol
@@ -1,6 +1,6 @@
 A=1000 n=1000 pr=0 sp=0 dv=(9.6+2.4*pr)*n so=1-sp o=160000 e=8*o c=""
 z="origin_" mr=z+"north" br=z+"south" cr=z+"east" z+="west" sm="\nS: " 
-u=e*3/13 l=2*o mm=l*13/19 k=e*3/19 sl="\nsignal lost" x/=so sm=c s=c 
+u=e*3/13 l=2*o mm=l*13/19 k=e*3/19 sl="\nsignal lost" x/=so sm=c ss=c 
 rr="ISAN2 :_\n     " xm="\nX: " ym="\nY: " zm="\nZ: " nn=l*13/3 
 ej=16*sp h="Q" pj=14-pr b=0.5 p=1000000 :at=mr :bt=br :ct=cr :dt=z x=0 
 t=p-:a t*=t i=p-:b i*=i g=p-:c g*=g f=p-:d f*=f x/=:a*:b*:c*:d goto14 


### PR DESCRIPTION
# Bug Fix

**What's new**
 - Fixes a bug where the newly renamed `ss` variable was not being set to an empty string initially, causing an extra `0` string to be added onto the end of the display when speed was not enabled, making the Z-coordinate appear to have an extra `0`.

NOTE: I am not familiar with YASM syntax, so I'm not sure if I fixed that file correctly.

@Collective-SB/isan-dev-team